### PR TITLE
Get the FROM commands from a docker file

### DIFF
--- a/bored-robot.cabal
+++ b/bored-robot.cabal
@@ -16,6 +16,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Lib
                      , CI.CurrentTime
+                     , CI.Docker.Parse
                      , CI.Filesystem
                      , CI.Git
                      , CI.Docker
@@ -30,6 +31,7 @@ library
                      , cryptonite
                      , directory
                      , exceptions
+                     , language-dockerfile
                      , more-extensible-effects
                      , process-extras
                      , text

--- a/src/CI/Docker/Parse.hs
+++ b/src/CI/Docker/Parse.hs
@@ -1,0 +1,11 @@
+module CI.Docker.Parse where
+
+import Data.Maybe
+import Language.Dockerfile
+
+getFroms :: Dockerfile -> [BaseImage]
+getFroms = mapMaybe getFrom
+
+getFrom :: InstructionPos -> Maybe BaseImage
+getFrom (InstructionPos (From b) _ _) = Just b
+getFrom _ = Nothing


### PR DESCRIPTION
So, a dockerfile can have multiple FROM commands in it, each one creating a different image.

>FROM can appear multiple times within a single Dockerfile in order to create multiple images. Simply make a note of the last image ID output by the commit before each new FROM command.

Sounds bad.