### PR TITLE
Reexport docker parsing stuff

### DIFF
--- a/src/CI/Docker/Parse.hs
+++ b/src/CI/Docker/Parse.hs
@@ -1,4 +1,16 @@
-module CI.Docker.Parse where
+module CI.Docker.Parse
+    ( getFroms
+    , getFrom
+    , Language.Dockerfile.parseString
+    , Language.Dockerfile.parseFile
+    , Language.Dockerfile.prettyPrint
+    , Language.Dockerfile.prettyPrintInstructionPos
+    , Language.Dockerfile.Dockerfile
+    , Language.Dockerfile.InstructionPos(..)
+    , Language.Dockerfile.Instruction(..)
+    , Language.Dockerfile.BaseImage(..)
+    , Language.Dockerfile.Tag
+    ) where
 
 import Data.Maybe
 import Language.Dockerfile


### PR DESCRIPTION
I thought about exporting the whole module, but it does a lot more than just parse, so I was selective.