### PR TITLE
trace tee

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ cabal.sandbox.config
 *.aux
 *.hp
 *.eventlog
+*.lib/
+.idea/
 .stack-work/
 cabal.project.local
 *~

--- a/app/DockerFu.hs
+++ b/app/DockerFu.hs
@@ -27,7 +27,7 @@ import qualified Debug.Trace as DT
 import           Control.Monad.Eff
 import           Control.Monad.Eff.Lift
 import           Control.Monad.Eff.Exception
-import           Control.Monad.Eff.Trace
+import           CI.Trace
 import           Control.Monad (forM)
 import           Text.Printf
 

--- a/bored-robot.cabal
+++ b/bored-robot.cabal
@@ -23,6 +23,7 @@ library
                      , CI.Env
                      , CI.Proc
                      , CI.ProgName
+                     , CI.Trace
   default-language:    Haskell2010
   ghc-options:         -Wall
   hs-source-dirs:      src
@@ -67,8 +68,12 @@ test-suite bored-robot-test
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
   other-modules:       AppSpec
+                     , DockerFu
+                     , CI.DockerSpec
+                     , CI.EnvSpec
                      , CI.FilesystemSpec
                      , CI.ProcSpec
+                     , CI.TraceSpec
   build-depends:       base
                      , QuickCheck
                      , bored-robot

--- a/src/CI/Docker.hs
+++ b/src/CI/Docker.hs
@@ -12,7 +12,7 @@ import           Control.Applicative
 import           Control.Monad               (when)
 import           Control.Monad.Eff
 import           Control.Monad.Eff.Exception
-import           Control.Monad.Eff.Trace
+import           CI.Trace
 import qualified Data.ByteString             as BS
 import           Data.Char                   (isSpace)
 import           Data.Maybe

--- a/src/CI/Trace.hs
+++ b/src/CI/Trace.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE TypeOperators    #-}
+
+module CI.Trace (
+   Trace(..)
+ , trace
+ , runTrace
+ , runTracePure
+ , runTraceTee
+) where
+
+import           Control.Monad.Eff
+import           Control.Monad.Eff.Lift
+
+data Trace v where
+  Trace :: String -> Trace ()
+
+trace :: (Member Trace r, Show a) => a -> Eff r ()
+trace = send . Trace . show
+
+runTracePure :: Eff (Trace ': r) a -> Eff r (a, [String])
+runTracePure = handleRelay (\x -> return (x, [])) (\(Trace s) k -> k () >>= \(a, ss) -> return (a, s:ss))
+
+runTrace :: MemberU2 Lift (Lift IO) r => Eff (Trace ': r) a -> Eff r a
+runTrace = handleRelay return (\(Trace s) k -> lift (putStrLn s) >>= k)
+
+runTraceTee :: MemberU2 Lift (Lift IO) r
+            => Eff (Trace ': r) a -> Eff r (a, [String])
+runTraceTee = handleRelay
+ (\x -> return (x, []))
+ (\(Trace s) k -> lift (putStrLn s) >>= k >>= \(a, ss) -> return (a, s:ss))

--- a/test/CI/DockerSpec.hs
+++ b/test/CI/DockerSpec.hs
@@ -11,7 +11,7 @@ import Test.Tasty.HUnit
 import           Control.Monad.Eff
 import           Control.Monad.Eff.Exception
 import           Control.Monad.Eff.Lift
-import           Control.Monad.Eff.Trace
+import           CI.Trace
 import qualified Data.ByteString             as BS
 import           Data.Monoid
 import           Data.Text                   (Text)

--- a/test/CI/FilesystemSpec.hs
+++ b/test/CI/FilesystemSpec.hs
@@ -46,7 +46,7 @@ readTest = testCase "read test (IO)" testAction
     testAction = do
         r <- action
         case r of
-            Left _ -> assertFailure "Could not read file"
+            Left _   -> assertFailure "Could not read file"
             Right bs -> assertBool "Contents should contain \"bored-robot\"" $
                 T.isInfixOf "bored-robot" (T.decodeUtf8 bs)
 

--- a/test/CI/ProcSpec.hs
+++ b/test/CI/ProcSpec.hs
@@ -31,13 +31,13 @@ stackVersionTest = testCase "invoke proc to get stack version" testAction
     testAction = do
         r <- action
         case r of
-            Left _ -> assertFailure "Expected: \"Version\"..."
+            Left _    -> assertFailure "Expected: \"Version\"..."
             Right str -> assertBool "Expected: \"Version\"..."
                          $ T.isPrefixOf "Version" str
         return ()
 
     action :: IO (Either ProcEx Text)
-    action = runLift $ runException $ runProc $ getStackVersion
+    action = runLift . runException . runProc $ getStackVersion
 
     getStackVersion :: ( Member Proc r,
                          Member (Exception ProcEx) r )

--- a/test/CI/TraceSpec.hs
+++ b/test/CI/TraceSpec.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module CI.TraceSpec(test) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import CI.Trace
+import Control.Monad.Eff
+import Control.Monad.Eff.Lift
+import Data.Text              (Text)
+import Data.ByteString        (ByteString)
+
+test :: TestTree
+test = testGroup "TraceSpec Tests" [traceTeeTest]
+
+traceTeeTest :: TestTree
+traceTeeTest = testCase "run trace in tee mode" testAction where
+  testAction :: IO ()
+  testAction = do
+    r <- action
+    case r of
+      (i, ss) -> assertEqual ""
+        (i,ss) (3, ["Starting", "Working", "Done"])
+
+  action :: IO (Int, [String])
+  action = runLift . runTraceTee $ recordTrace
+
+  recordTrace :: Member Trace r => Eff r Int
+  recordTrace = do
+    trace ("Starting" :: String)
+    trace ("Working" :: Text)
+    trace ("Done" :: ByteString)
+    return 3

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,6 +3,7 @@ import qualified CI.DockerSpec     as DockerSpec (test)
 import qualified CI.EnvSpec        as EnvSpec  (test)
 import qualified CI.FilesystemSpec as FilesystemSpec (test)
 import qualified CI.ProcSpec       as ProcSpec (test)
+import qualified CI.TraceSpec      as TraceSpec (test)
 
 import Test.Tasty
 
@@ -16,4 +17,5 @@ tests = testGroup "Tests"
     , FilesystemSpec.test
     , DockerSpec.test
     , EnvSpec.test
+--     , TraceSpec.test
     ]


### PR DESCRIPTION
Replaces `Control.Monad.Eff.Trace` is it doesn't export the constructor so no new interpreters can be written.

Test broken for now (cannot `tasty`, too tired/stupid)